### PR TITLE
表示してるセクションと目次を同期してハイライト

### DIFF
--- a/docinfo.html
+++ b/docinfo.html
@@ -1,1 +1,2 @@
 <link rel="stylesheet" type="text/css" href="public/css/overload.css"/>
+<script type="text/javascript" src="public/js/sync-toc.js"></script>

--- a/public/css/overload.css
+++ b/public/css/overload.css
@@ -3,3 +3,14 @@
     margin-bottom: 30px;
     border-bottom: 1px solid rgb(134, 150, 165);
 }
+
+li > a.sc-current-element:before {
+    content: "";
+    left: 0;
+    position: absolute;
+    width: 5px;
+    height: 1.5em;
+    background-color: #ffa500;
+    transition-property: background-color, color;
+    transition-duration: 0.3s;
+}

--- a/public/js/sync-toc.js
+++ b/public/js/sync-toc.js
@@ -1,0 +1,79 @@
+"use strict";
+
+function TOCHighlighter(sections, tocAList, headerNames, highlightClassName) {
+    var toArray = Function.prototype.call.bind(Array.prototype.slice);
+    this.sections = toArray(sections);
+    this.tocAList = toArray(tocAList);
+    this.headerNames = headerNames;
+    this.highlightClassName = highlightClassName || "sc-current-element";
+}
+TOCHighlighter.prototype.updateCurrentTOC = function () {
+    var currentTOCElement = this.currentTOCElements().pop();
+    var isCurrentTOC = function (element) {
+        return currentTOCElement === element;
+    };
+
+    this.tocAList.forEach(function (element) {
+        if (isCurrentTOC(element)) {
+            element.classList.add(this.highlightClassName);
+        } else {
+            element.classList.remove(this.highlightClassName);
+        }
+    }, this);
+};
+TOCHighlighter.prototype.currentTOCElements = function () {
+    var headerIDs = this.currentHeaders().map(function (element) {
+        return element.getAttribute("id");
+    });
+    return this.tocAList.filter(function (element) {
+        return headerIDs.indexOf(element.hash.split("#")[1]) !== -1;
+    });
+
+};
+TOCHighlighter.prototype.currentHeaders = function () {
+    var wScrollTop = document.documentElement.scrollTop || document.body.scrollTop;
+    var isHeaderElement = function (element) {
+        return element != null && element.hasAttribute("id");
+    };
+    var elements = this.sections.map(function (element) {
+        return this.contentInElement(element, wScrollTop).pop();
+    }, this);
+    return elements.filter(isHeaderElement);
+};
+TOCHighlighter.prototype.contentInElement = function (element, wScrollTop) {
+    var originY = element.offsetTop,
+        sectionHeight = element.offsetHeight;
+    if (originY <= wScrollTop && wScrollTop <= originY + sectionHeight) {
+        return this.findAllChildHeader(element);
+    }
+    return [];
+};
+TOCHighlighter.prototype.findAllChildHeader = function (parent) {
+    var children = parent.children;
+    for (var i = 0; i < children.length; i++) {
+        var child = children[i];
+        if (this.headerNames.indexOf(child.nodeName.toLowerCase()) !== -1) {
+            return [child];
+        }
+    }
+    return [];
+};
+window.addEventListener("load", function onLoad() {
+    var highLightLevel = ["h1", "h2", "h3"];
+    var chapters = document.querySelectorAll(".sect1");
+    var sections = document.querySelectorAll(".sect2");
+    var tocAList = document.querySelectorAll("#toc a");
+    var sectionHighlighter = new TOCHighlighter(sections, tocAList, highLightLevel);
+    var chapterHighlighter = new TOCHighlighter(chapters, tocAList, highLightLevel, "ch-current-element");
+
+    function updateTOC() {
+        sectionHighlighter.updateCurrentTOC();
+        chapterHighlighter.updateCurrentTOC();
+    }
+
+    function onScroll() {
+        requestAnimationFrame && requestAnimationFrame(updateTOC);
+    }
+
+    window.addEventListener("scroll", onScroll);
+});


### PR DESCRIPTION
#38
- [x] 表示してるセクションと目次を同期してハイライトする機能を追加

`requestAnimationFrame`や高階関数等を多用してるのでIE9以下は多分動かない
表示的なやつだから別に動くブラウザ使えばいいという話
