### PR TITLE
chore(promise-chain): Arrayのメソッドチェーンについての改善

### DIFF
--- a/Ch4_AdvancedPromises/promise-chain.adoc
+++ b/Ch4_AdvancedPromises/promise-chain.adoc
@@ -204,7 +204,7 @@ fs.readFileAsync("myfile.js", "utf8").then(function(contents){
 次のようなネイティブ`Array`のPromise版を使えるメソッドを動的に定義する例を考えてみましょう。
 
 JavaScriptにはネイティブにもDOMやString等メソッドチェーンが行える機能が多くあります。
-`Array`もその一つで`map`や`filter`等の高階関数を受け取って処理はメソッドチェーンが利用しやすい機能です。
+`Array`もその一つで、`map`や`filter`等のメソッドは配列を返すため、メソッドチェーンが利用しやすい機能です
 
 [source,javascript]
 [[array-promise-chain.js]]


### PR DESCRIPTION
https://github.com/azu/promises-book/issues/148

https://github.com/azu/promises-book/issues/148#issuecomment-46010208 の反映

> Arrayもその一つでmapやfilter等のメソッドは配列を返すため、メソッドチェーンが利用しやすい機能です

@vzvu3k6k こんな感じでどうでしょうか?
