### PR TITLE
node_modulesのgulpのみを使う

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ before_install:
 - gem --version
 - gem install asciidoctor
 - gem install coderay
-- npm install -g gulp
 - sudo apt-get install ttf-vlgothic
 script:
 - make test

--- a/Makefile
+++ b/Makefile
@@ -7,19 +7,19 @@ all: clean html
 test:
 	@npm test
 	@make html
-	@gulp lint-html
+	@npm run lint-html
 
 html:
 	@echo "Generate HTML..."
-	@gulp embed
-	@gulp build-js
+	@npm run embed
+	@npm run build-js
 	@echo "Building asciidoc"
 	@./_tools/build.sh
 	@echo "Done! => ${OUTPUT_FILE}"
 
 pdf:
 	@echo "Generate PDF..."
-	@gulp embed
+	@npm run embed
 	@echo "Building asciidoc"
 	@asciidoctor -a lang=en -a bookversion=`node ./_tools/cli-book-version.js` \
 	-a icons=font -a source-highlighter=coderay --backend docbook \
@@ -29,7 +29,7 @@ pdf:
 
 pdf-note:
 	@echo "Generate PDF..."
-	@gulp embed
+	@npm run embed
 	@echo "Building asciidoc"
 	@asciidoctor -a lang=en -a icons=font -a source-highlighter=coderay --backend docbook \
 	-o javascript-promise-omake.xml Appendix-Note/readme.adoc

--- a/_tools/deploy-gh-pages.sh
+++ b/_tools/deploy-gh-pages.sh
@@ -16,7 +16,7 @@ fi
 git checkout -B gh-pages
 
 make html
-gulp build-min-js
+npm run build-min-js
 
 make pdf
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -52,7 +52,7 @@ gulp.task("embed", function () {
         .pipe(gulp.dest("./"));
 });
 gulp.task("lint-html", function (callback) {
-    global.Promise = require("ypromise");
+    require("ypromise");
     var File = require("./Ch4_AdvancedPromises/src/promise-chain/fs-promise-chain");
     var checkHTML = require("./test/html/missing-internal-link").checkInternalLinks;
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
   },
   "main": "index.js",
   "scripts": {
+    "build-js": "gulp build-js",
+    "build-js-min": "gulp build-min-js",
+    "embed": "gulp embed",
+    "lint-html": "gulp lint-html",
     "test": "mocha ./Ch**/test/*.js"
   },
   "directories": {
@@ -33,7 +37,7 @@
     "esprima": "^2.0.0",
     "esprima-fb": "^4001.1.0-dev-harmony-fb",
     "fs-extra": "^0.16.3",
-    "gulp": "^3.6.2",
+    "gulp": "^3.8.11",
     "gulp-inlining-node-require": "0.0.3",
     "gulp-remove-use-strict": "0.0.2",
     "gulp-rename": "~1.2.0",

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,6 @@ This book has been released in :
 
 ``` sh
 gem install asciidoctor coderay
-npm install -g gulp
 npm install
 make html
 open index.html


### PR DESCRIPTION
```
npm i -g gulp
```

は不要にできるはずなので、ビルドスクリプトを変更する。

- [x] npm run-scriptの追加
- [x] READMEの変更
- [x] travis.ymlの変更