### PR TITLE
Ch3: assert.deepEqualの使い方が間違っている

### DIFF
--- a/Ch3_Testing/mocha-promise.adoc
+++ b/Ch3_Testing/mocha-promise.adoc
@@ -110,7 +110,7 @@ function mayBeRejected(){
 }
 it("should bad pattern", function () {
     return mayBeRejected().then(failTest).catch(function (error) {
-        assert.deepEqual(error.message === "woo");
+        assert(error.message === "woo");
     });
 });
 ----

--- a/_tools/deploy-gh-pages.sh
+++ b/_tools/deploy-gh-pages.sh
@@ -2,6 +2,10 @@
 
 declare currentDir=$(cd $(dirname $0);pwd)
 
+if [ "$TRAVIS_BRANCH" != "master" ] ; then
+    exit 0;
+fi
+
 if [ $TRAVIS_PULL_REQUEST != 'false' ]; then
     echo "This is a pull request. No deployment will be done.";
     exit 0;


### PR DESCRIPTION
```js
assert.deepEqual(error.message === "woo");
```

を

```js
assert(error.message === "woo")
```

へ変更する