### PR TITLE
fix(src): Ch2でのサンプルソースにセミコロンが抜けていた問題の修正

### DIFF
--- a/Ch2_HowToWrite/src/promise-then-taska-throw.js
+++ b/Ch2_HowToWrite/src/promise-then-taska-throw.js
@@ -1,6 +1,6 @@
 function taskA() {
     console.log("Task A");
-    throw new Error("throw Error @ Task A")
+    throw new Error("throw Error @ Task A");
 }
 function taskB() {
     console.log("Task B");// 呼ばれない


### PR DESCRIPTION
Ch2でのサンプルソース（promise-then-taska-throw.js）にて
セミコロンが抜けていました。
jsbinでソースをコピペするとエラーとなるため、修正のため
pull requestを出した次第です。