### PR TITLE
chore(promise-all): fix typo

### DIFF
--- a/Ch2_HowToWrite/promise-all.adoc
+++ b/Ch2_HowToWrite/promise-all.adoc
@@ -8,7 +8,7 @@
 
 先ほどの例の `getURL` はXHRによる通信を抽象化したpromiseオブジェクトを返しています。
 `Promise.all` に通信を抽象化したpromiseオブジェクトの配列を渡すことで、
-全ての通信が完了(FulFilledまたRejected)した時に、次の `.then` を呼び出すことが出来ます。
+全ての通信が完了(FulFilledまたはRejected)した時に、次の `.then` を呼び出すことが出来ます。
 
 [role="executable"]
 [source,javascript]


### PR DESCRIPTION
「また」 -> 「または」の修正です。

この pull request とは直接関係ないのですが、[CONTRIBUTING.md の Gitのコミットメッセージ](https://github.com/azu/promises-book/blob/c2b8df3a0550ddba9e15cbc5893bcc02ea20f330/CONTRIBUTING.md#git%E3%81%AE%E3%82%B3%E3%83%9F%E3%83%83%E3%83%88%E3%83%A1%E3%83%83%E3%82%BB%E3%83%BC%E3%82%B8)のリンク先の CONVENTIONS.md がなくなっているようです。