### PR TITLE
Deferred object will be Promises/A+ compatible on jQuery 3.0 or later.

### DIFF
--- a/Ch2_HowToWrite/promise-resolve.adoc
+++ b/Ch2_HowToWrite/promise-resolve.adoc
@@ -90,6 +90,8 @@ https://api.jquery.com/jQuery.ajax/[jQuery.ajax()]の返り値も `.then` とい
 
 なお、jQuery 3.0からは、 http://api.jquery.com/category/deferred-object/[Deferred Object]や http://api.jquery.com/jQuery.ajax/#jqXHR[jqXHR Object]が<<promises-aplus,Promises/A+>>準拠になる予定です。
 
+* https://blog.jquery.com/2016/01/14/jquery-3-0-beta-released/[jQuery 3.0 Beta Released | Official jQuery Blog]
+
 ====
 
 `Promise.resolve` は共通の挙動である `then` だけを利用して、

--- a/Ch2_HowToWrite/promise-resolve.adoc
+++ b/Ch2_HowToWrite/promise-resolve.adoc
@@ -87,6 +87,9 @@ https://api.jquery.com/jQuery.ajax/[jQuery.ajax()]の返り値も `.then` とい
 * http://www.html5rocks.com/ja/tutorials/es6/promises/#toc-lib-compatibility[JavaScript Promises: There and back again - HTML5 Rocks]
 * http://domenic.me/2012/10/14/youre-missing-the-point-of-promises/[You&#39;re Missing the Point of Promises]
 * https://twitter.com/hirano_y_aa/status/398851806383452160[https://twitter.com/hirano_y_aa/status/398851806383452160]
+
+なお、jQuery 3.0からは、 http://api.jquery.com/category/deferred-object/[Deferred Object]や http://api.jquery.com/jQuery.ajax/#jqXHR[jqXHR Object]が<<promises-aplus,Promises/A+>>準拠になる予定です。
+
 ====
 
 `Promise.resolve` は共通の挙動である `then` だけを利用して、


### PR DESCRIPTION
jQuery 3.0からDeferredがPromises/A+準拠になるので一言触れておくとよいかと思い、その記述を追加しました。

https://blog.jquery.com/2016/01/14/jquery-3-0-beta-released/