### PR TITLE
chore(Ch1): 名前付き関数式の復元

### DIFF
--- a/Ch1_WhatsPromises/writing-promises.adoc
+++ b/Ch1_WhatsPromises/writing-promises.adoc
@@ -90,7 +90,7 @@ resolveされたことにより _promiseオブジェクトがFulFilledの状態�
 [source,javascript]
 ----
 const URL = "https://httpbin.org/get";
-fetchURL(URL).then((value) => { // <1>
+fetchURL(URL).then(function onFulfilled(value){ // <1>
     console.log(value);
 });
 ----
@@ -112,9 +112,9 @@ rejectされたことより _promiseオブジェクトがRejectedの状態にな
 [source,javascript]
 ----
 const URL = "https://httpbin.org/status/500"; // <1>
-fetchURL(URL).then((value) => {
+fetchURL(URL).then(function onFulfilled(value){
     console.log(value);
-}).catch((error) => { // <2>
+}).catch(function onRejected(error){ // <2>
     console.error(error);
 });
 ----


### PR DESCRIPTION
ES2015への移行でArrow Functionに過剰修正された関数を名前付き関数式に復元