### PR TITLE
chore: erights.orgのリンク切れが復活していたので対応

### DIFF
--- a/Ch1_WhatsPromises/what-is-promise.adoc
+++ b/Ch1_WhatsPromises/what-is-promise.adoc
@@ -6,7 +6,7 @@
 Promiseは非同期処理を抽象化したオブジェクトとそれを操作する仕組みのことをいいます。
 詳しくはこれから学んでいくとして、PromiseはJavaScriptで発見された概念ではありません。
 
-最初に発見されたのは https://web.archive.org/web/20161029030824/http://erights.org/elib/distrib/pipeline.html[E言語]におけるもので、
+最初に発見されたのは http://erights.org/elib/distrib/pipeline.html[E言語]におけるもので、
 並列/並行処理におけるプログラミング言語のデザインの一種です。
 
 このデザインをJavaScriptに持ってきたものが、この書籍で学ぶJavaScript Promiseです。


### PR DESCRIPTION
https://github.com/azu/promises-book/pull/277 でリンク先をArchiveに変えていましたが、元々のリンク先が復活していたので、元に戻します。
※ revertするとコンフリクトしたため、このcommit https://github.com/azu/promises-book/commit/289422afb443483d061afe1847a99c923b419788 で対応しています。