### PR TITLE
refactor: fs-extra を使わずに node:fs を使うようにした

### DIFF
--- a/Ch4_AdvancedPromises/test/fs-method-chain-test.js
+++ b/Ch4_AdvancedPromises/test/fs-method-chain-test.js
@@ -1,6 +1,6 @@
 "use strict";
 const assert = require("power-assert");
-const fs = require("fs-extra");
+const fs = require("node:fs");
 const File = require("../src/promise-chain/fs-method-chain");
 File.prototype.then = function(fn) {
     fn.call(this, this.lastValue);
@@ -10,10 +10,11 @@ describe("File", () => {
     const fixtureDir = __dirname + "/__fixtures";
     const inputFilePath = fixtureDir + "/input.txt";
     beforeEach(() => {
-        fs.copySync(__dirname + "/fixtures", fixtureDir);
+        fs.mkdirSync(fixtureDir);
+        fs.copyFileSync(__dirname + "/fixtures/input.txt", inputFilePath);
     });
     afterEach(() => {
-        fs.removeSync(fixtureDir);
+        fs.rmSync(fixtureDir, { recursive: true, force: true });
     });
     describe("read", () => {
         context("when not found", () => {

--- a/Ch4_AdvancedPromises/test/fs-promise-chain-test.js
+++ b/Ch4_AdvancedPromises/test/fs-promise-chain-test.js
@@ -1,15 +1,16 @@
 "use strict";
 const assert = require("power-assert");
-const fs = require("fs-extra");
+const fs = require("node:fs");
 const File = require("../src/promise-chain/fs-promise-chain");
 describe("File-Promised", () => {
     const fixtureDir = __dirname + "/__fixtures";
     const inputFilePath = fixtureDir + "/input.txt";
     beforeEach(() => {
-        fs.copySync(__dirname + "/fixtures", fixtureDir);
+        fs.mkdirSync(fixtureDir);
+        fs.copyFileSync(__dirname + "/fixtures/input.txt", inputFilePath);
     });
     afterEach(() => {
-        fs.removeSync(fixtureDir);
+        fs.rmSync(fixtureDir, { recursive: true, force: true });
     });
     describe("read", () => {
         context("when not found", () => {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "eslint": "^8.32.0",
     "espower-loader": "^1.0.0",
     "esprima": "^4.0.1",
-    "fs-extra": "^8.1.0",
+    "fs-extra": "^11.3.0",
     "globby": "^10.0.1",
     "gulp": "^4.0.2",
     "gulp-concat": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "eslint": "^8.32.0",
     "espower-loader": "^1.0.0",
     "esprima": "^4.0.1",
-    "fs-extra": "^11.3.0",
     "globby": "^10.0.1",
     "gulp": "^4.0.2",
     "gulp-concat": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3002,14 +3002,14 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-fs-extra@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
-  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
+fs-extra@^11.3.0:
+  version "11.3.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.3.0.tgz#0daced136bbaf65a555a326719af931adc7a314d"
+  integrity sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==
   dependencies:
     graceful-fs "^4.2.0"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs-mkdirp-stream@^1.0.0:
   version "1.0.0"
@@ -4086,10 +4086,12 @@ json5@^2.2.2:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
-jsonfile@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
-  integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
+jsonfile@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
+  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+  dependencies:
+    universalify "^2.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
 
@@ -7212,10 +7214,10 @@ universal-deep-strict-equal@^1.2.1:
     indexof "0.0.1"
     object-keys "^1.0.0"
 
-universalify@^0.1.0:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
-  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+universalify@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d"
+  integrity sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==
 
 unset-value@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3002,15 +3002,6 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-fs-extra@^11.3.0:
-  version "11.3.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.3.0.tgz#0daced136bbaf65a555a326719af931adc7a314d"
-  integrity sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==
-  dependencies:
-    graceful-fs "^4.2.0"
-    jsonfile "^6.0.1"
-    universalify "^2.0.0"
-
 fs-mkdirp-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz#0b7815fc3201c6a69e14db98ce098c16935259eb"
@@ -3238,7 +3229,7 @@ glogg@^1.0.0:
   dependencies:
     sparkles "^1.0.0"
 
-graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
@@ -4085,15 +4076,6 @@ json5@^2.2.2:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
-
-jsonfile@^6.0.1:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
-  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
-  dependencies:
-    universalify "^2.0.0"
-  optionalDependencies:
-    graceful-fs "^4.1.6"
 
 jsonify@~0.0.0:
   version "0.0.0"
@@ -7213,11 +7195,6 @@ universal-deep-strict-equal@^1.2.1:
     array-filter "^1.0.0"
     indexof "0.0.1"
     object-keys "^1.0.0"
-
-universalify@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d"
-  integrity sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==
 
 unset-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
~~fs-extra を v8 → v11 へアップデート~~
- ~~<https://github.com/jprichardson/node-fs-extra/blob/master/CHANGELOG.md>~~

fs-extra を使わずに node:fs を使うようにした