### PR TITLE
refactor: through2 を使わず node の stream を使うようにした

### DIFF
--- a/_tools/gulp/format-code.js
+++ b/_tools/gulp/format-code.js
@@ -1,18 +1,21 @@
-var through2 = require('through2');
-var reg = /require\(["']power-assert["']\)/g;
+const { Transform } = require("stream");
+const reg = /require\(["']power-assert["']\)/g;
 
 function modifier(str) {
     // power-assert -> assert
     // strict use strict
-    return str.replace(reg, 'require("assert")').replace(/["']use strict["'];?\n/g, "")
+    return str.replace(reg, "require(\"assert\")").replace(/["']use strict["'];?\n/g, "");
 }
 
 function modify() {
-    return through2.obj(function (file, encoding, done) {
-        var content = modifier(String(file.contents));
-        file.contents = new Buffer(content);
-        this.push(file);
-        done();
+    return new Transform({
+        objectMode: true,
+        transform(file, encoding, callback) {
+            const content = modifier(String(file.contents));
+            file.contents = Buffer.from(content);
+            this.push(file);
+            callback();
+        }
     });
 }
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "textlint-plugin-asciidoctor": "^1.0.3",
     "textlint-rule-eslint": "4.0.1",
     "textlint-rule-prh": "^5.2.1",
-    "through2": "^3.0.1",
     "vinyl-source-stream": "^2.0.0"
   }
 }


### PR DESCRIPTION
`format-code.js` で [through2](https://github.com/rvagg/through2) を使わず node の stream を使うようにした